### PR TITLE
Read collection_id from collection

### DIFF
--- a/actinia_stac_plugin/apidocs/stac_collections_docs.py
+++ b/actinia_stac_plugin/apidocs/stac_collections_docs.py
@@ -49,7 +49,7 @@ staccollection_post_docs = {
                     "stac_instance_id": {
                         "type": "string",
                         "description": "instance id where the collection will be stored",
-                        "example": "ProjectIntance",
+                        "example": "ProjectInstance",
                     },
                     "stac_url": {
                         "type": "string",

--- a/actinia_stac_plugin/core/stac_collections.py
+++ b/actinia_stac_plugin/core/stac_collections.py
@@ -136,8 +136,12 @@ def addStacCollection(parameters):
 
     if stac_instance_id and stac_root:
         root_validation = collectionValidation(parameters["stac_url"])
+
+        stac_json_collection = requests.get(parameters["stac_url"])
+        stac_collection_id = stac_json_collection.json()["id"]
+
         collection_validation = re.match(
-            "^[a-zA-Z0-9_]*$", parameters["stac_collection_id"]
+            "^[a-zA-Z0-9-_]*$", stac_collection_id
         )
         instance_validation = re.match(
             "^[a-zA-Z0-9_]*$", parameters["stac_instance_id"]
@@ -161,5 +165,5 @@ def addStacCollection(parameters):
         return msg
     else:
         return {
-            "message": "Check the parameters (stac_instance_id,stac_collection_id,stac_url)"
+            "message": "Check the parameters (stac_instance_id,stac_url)"
         }

--- a/actinia_stac_plugin/core/stac_collections.py
+++ b/actinia_stac_plugin/core/stac_collections.py
@@ -81,6 +81,8 @@ def addStac2User(jsonParameters):
     # Splitting the inputs
     stac_instance_id = jsonParameters["stac_instance_id"]
     stac_root = resolveCollectionURL(jsonParameters["stac_url"])
+    stac_json_collection = jsonParameters["collection"]
+    stac_collection_id = jsonParameters["stac_collection_id"]
 
     # Verifying the existence of the instances - Adding the item to the Default List
     list_instances_exist = redis_actinia_interface.exists("stac_instances")
@@ -95,8 +97,6 @@ def addStac2User(jsonParameters):
     if stac_instance_id and stac_root:
 
         # Caching JSON from the STAC collection
-        stac_json_collection = requests.get(stac_root)
-        stac_collection_id = stac_json_collection.json()["id"]
         stac_unique_id = (
             "stac." + stac_instance_id + ".rastercube." + stac_collection_id
         )
@@ -137,11 +137,11 @@ def addStacCollection(parameters):
     if stac_instance_id and stac_root:
         root_validation = collectionValidation(parameters["stac_url"])
 
-        stac_json_collection = requests.get(parameters["stac_url"])
-        stac_collection_id = stac_json_collection.json()["id"]
+        parameters["collection"] = requests.get(parameters["stac_url"])
+        parameters["stac_collection_id"] = parameters["collection"].json()["id"]
 
         collection_validation = re.match(
-            "^[a-zA-Z0-9-_]*$", stac_collection_id
+            "^[a-zA-Z0-9-_]*$", parameters["stac_collection_id"]
         )
         instance_validation = re.match(
             "^[a-zA-Z0-9_]*$", parameters["stac_instance_id"]


### PR DESCRIPTION
Leftover from https://github.com/mundialis/actinia-stac-plugin/issues/27
The method `addStacCollection` was still trying to read the collection id from parameters in POST body. As this no longer exists, this PR makes the HTTP GET request to the STAC collection already one step earlier to parse the ID and validate it.