### PR TITLE
Return long collection id instead of original one

### DIFF
--- a/actinia_stac_plugin/core/stac_collection_id.py
+++ b/actinia_stac_plugin/core/stac_collection_id.py
@@ -37,7 +37,7 @@ def callStacCollection(stac_collection_id: str):
         # overwrite original ID with generated ID
         resp['id'] = stac_collection_id
     except Exception:
-        stac = {
+        resp = {
             "Error": "Something went wrong, please check the collection to retrieved"
         }
 

--- a/actinia_stac_plugin/core/stac_collection_id.py
+++ b/actinia_stac_plugin/core/stac_collection_id.py
@@ -23,6 +23,8 @@ __copyright__ = "2018-2021 mundialis GmbH & Co. KG"
 __license__ = "GPLv3"
 __maintainer__ = "__mundialis__"
 
+import json
+
 from actinia_stac_plugin.core.stac_redis_interface import redis_actinia_interface
 from actinia_stac_plugin.core.common import readStacCollection, connectRedis
 
@@ -31,12 +33,15 @@ def callStacCollection(stac_collection_id: str):
     try:
         instance_id = stac_collection_id.split(".")[1]
         stac = readStacCollection(instance_id, stac_collection_id)
+        resp = json.loads(stac)
+        # overwrite original ID with generated ID
+        resp['id'] = stac_collection_id
     except Exception:
         stac = {
             "Error": "Something went wrong, please check the collection to retrieved"
         }
 
-    return stac
+    return resp
 
 
 def deleteStacCollection(stac_instance_id: str, stac_collection_id: str):

--- a/actinia_stac_plugin/core/stac_collections.py
+++ b/actinia_stac_plugin/core/stac_collections.py
@@ -53,6 +53,11 @@ def StacCollectionsList():
                     stac = stac.decode("utf8").replace("'", '"')
                 except Exception:
                     stac = stac
+                # if response is slow (especially with growing collections),
+                # it might be an option to use pickle to store json in redis
+                json_collection = json.loads(stac)
+                json_collection['id'] = i
+                stac = json.dumps(json_collection)
                 stac_inventary["collections"].append(json.loads(stac))
     else:
         collections = defaultInstance()

--- a/actinia_stac_plugin/core/stac_collections.py
+++ b/actinia_stac_plugin/core/stac_collections.py
@@ -57,8 +57,7 @@ def StacCollectionsList():
                 # it might be an option to use pickle to store json in redis
                 json_collection = json.loads(stac)
                 json_collection['id'] = i
-                stac = json.dumps(json_collection)
-                stac_inventary["collections"].append(json.loads(stac))
+                stac_inventary["collections"].append(json_collection)
     else:
         collections = defaultInstance()
         stac_inventary["defaultStac"] = collections


### PR DESCRIPTION
Currently when requesting all collections or a single collection, the original JSON is returned including the original ID. As discussed, it would be more helpful to show the actinia id following the naming convention to be able to load a single collection.
Example is  `stac.ct.rastercube.sentinel-s2-l2a` now instead of plain `sentinel-s2-l2a`.

(Requesting this single ID is already using long ID style `http://127.0.0.1:8088/api/v1/stac/collections/stac.ct.rastercube.sentinel-s2-l2a`

The entry in redis is kept as is, only when loading it to return it, the id is ajusted before response is returned.