### PR TITLE
improve STAC validation

### DIFF
--- a/actinia_stac_plugin/core/common.py
+++ b/actinia_stac_plugin/core/common.py
@@ -38,7 +38,7 @@ def connectRedis():
     try:
         conf.read()
     except Exception:
-        print("Error")
+        print("Error reading configuration")
 
     server = conf.REDIS_SERVER_URL
     port = conf.REDIS_SERVER_PORT
@@ -98,22 +98,42 @@ def collectionValidation(url: str) -> bool:
     Verify that the URL provided belong to a STAC endpoint
     """
     stac = stac_validator.StacValidate(url)
-    stac.run()
-    valid = stac.message[0]["valid_stac"]
-    type = stac.message[0]["asset_type"]
-    if valid and type == "COLLECTION":
-        return True
-    else:
+    if stac.run() is False:
+        print("This <%s> is not a valid STAC collection" % stac)
         return False
+    if "valid_stac" not in stac.message[0].keys():
+        print("This <%s> is not a valid STAC collection" % stac)
+        return False
+    if stac.message[0]["valid_stac"] is False:
+        print("This <%s> is not a valid STAC collection" % stac)
+        return False
+    if "asset_type" not in stac.message[0].keys():
+        print("This <%s> is not a valid STAC collection" % stac)
+        return False
+    if stac.message[0]["asset_type"] != "COLLECTION":
+        print("This <%s> is not a valid STAC collection" % stac)
+        return False
+
+    return True
 
 
 def resolveCollectionURL(url):
-    collection_url = url
 
     stac = stac_validator.StacValidate(url)
-    stac.run()
-    type = stac.message[0]["asset_type"]
-    if type == "COLLECTION":
-        collection_url = url
+    if stac.run() is False:
+        print("This <%s> is not a valid STAC collection" % stac)
+        return None
+    if "valid_stac" not in stac.message[0].keys():
+        print("This <%s> is not a valid STAC collection" % stac)
+        return None
+    if stac.message[0]["valid_stac"] is False:
+        print("This <%s> is not a valid STAC collection" % stac)
+        return None
+    if "asset_type" not in stac.message[0].keys():
+        print("This <%s> is not a valid STAC collection" % stac)
+        return None
+    if stac.message[0]["asset_type"] != "COLLECTION":
+        print("This <%s> is not a valid STAC collection" % stac)
+        return None
 
-    return collection_url
+    return url

--- a/actinia_stac_plugin/core/stac_collections.py
+++ b/actinia_stac_plugin/core/stac_collections.py
@@ -100,6 +100,9 @@ def addStac2User(jsonParameters):
     if not stac_instance_exist:
         raise BadRequest("No Instance name matched")
 
+    if not stac_root:
+        raise BadRequest("<%s> is not a valid STAC collection" % jsonParameters["stac_url"])
+
     if stac_instance_id and stac_root:
 
         # Caching JSON from the STAC collection


### PR DESCRIPTION
Avoid key errors with invalid STAC collections.

What is yet missing are informative HTTP responses in case of invalid STAC collections. Something for a different MR?